### PR TITLE
Assorted instinct friendliness edits

### DIFF
--- a/dev/Scripts/1.6_Weather.cos
+++ b/dev/Scripts/1.6_Weather.cos
@@ -9,6 +9,8 @@
 *2 19 50202 - Snowflake
 *2 19 50207 - Dust Devil
 
+*The one who screams toned down the scares from thunder and stopped dustdevils from creating mushroom patches.
+
 new: comp 1 9 50200 "moe_C2toDS_Weather" 1 32 9000
 
 attr 34
@@ -321,11 +323,11 @@ scrp 1 9 50200 9
 		adds va00 "C"
 	else
 		mulv va00 100
-		
+
 		setv va00 ftoi va00
-		
+
 		sets va00 vtos va00
-		
+
 		adds va00 "ca"
 	endi
 
@@ -357,7 +359,7 @@ scrp 2 19 50200 10
 
 	elas 0
 
-	rnge 1999
+	rnge 570
 
 	seta ov04 targ
 
@@ -955,7 +957,7 @@ scrp 2 19 50200 1001
 
 		esee 4 0 0
 
-			chem 158 .5
+			chem 158 .1
 
 		next
 
@@ -1636,9 +1638,15 @@ scrp 2 19 50207 9
 
 		andv va04 32
 
+*		to prevent the uprising, don't carry mushrooms
+		doif fmly eq 2 and gnus eq 11 and spcs eq 50209
+
+				setv va05 1
+
+		endi
 
 
-		doif va04 ne 32 and va02 eq 2 and va03 eq 128 and accg gt 0 and carr eq null
+		doif va04 ne 32 and va02 eq 2 and va03 eq 128 and accg gt 0 and carr eq null and va05 ne 1
 
 			doif name "dustdevil" ne 1 and accg ge .1
 

--- a/dev/Scripts/2.0_Albian_Coconut.cos
+++ b/dev/Scripts/2.0_Albian_Coconut.cos
@@ -6,7 +6,7 @@
 * 2 10 50214 - Coconut Detritus
 
 *Matthew, "Moe", '10*
-* Some Modifications By the one who screams i guess
+* Some Modifications By the one who screams i guess (instinct friendliness, removed empty hunger decrease)
 * (if you worked on this file, feel free to add your name!)
 
 
@@ -432,11 +432,11 @@ scrp 2 8 50217 12
 
 	targ from
 
-	chem 151 -.31
+*	chem 151 -.31
 
-	chem 150 -.39
+*	chem 150 -.39
 
-	chem 149 -.27
+*	chem 149 -.27
 
 *	chem 10 .31
 

--- a/dev/Scripts/2.0_Arnica_Berries.cos
+++ b/dev/Scripts/2.0_Arnica_Berries.cos
@@ -4,6 +4,8 @@
 * 2 8 50208 - Arnica Berry
 
 *Matthew, "Moe", '10*
+*The one who screams removed empty hunger decreases, made berries invisible until picked,
+*and stopped berries from dying on the vine.
 
 new: simp 2 6 50208 "moe_C2toDS_berries" 0 0 5000
 
@@ -65,7 +67,7 @@ scrp 2 8 50208 10
 
 	bhvr 48
 
-	attr 195
+	attr 211
 
 	elas 10
 
@@ -73,7 +75,7 @@ scrp 2 8 50208 10
 
 	tick rand 500 1000
 
-	emit 6 .15
+*emit 6 .15
 
 	wait 1
 
@@ -97,17 +99,24 @@ scrp 2 8 50208 9
 
 		addv ov00 1
 
-		doif ov00 ge rand 10 50 and ov01 eq 1
+		doif ov01 eq 1
 
-			accg 4
+			doif ov00 ge rand 30 50
 
-			velo rand -5 5 0
+				accg 4
 
-		endi
+				attr 195
 
+				emit 6 .15
 
+				velo rand -5 5 0
 
-		doif ov00 ge rand 3 5
+				setv ov01 0
+
+				setv ov00 0
+			endi
+
+		elif ov00 ge rand 3 5
 
 			kill targ
 
@@ -138,6 +147,10 @@ endm
 scrp 2 8 50208 5
 
 	accg 4
+
+	attr 195
+
+	emit 6 .15
 
 endm
 
@@ -175,7 +188,7 @@ scrp 2 8 50208 12
 
 *Hunger for carbs Decrease*
 
-	chem 150 -.19
+*chem 150 -.19
 
 	targ ownr
 

--- a/dev/Scripts/2.0_Bryonia_Berry.cos
+++ b/dev/Scripts/2.0_Bryonia_Berry.cos
@@ -4,6 +4,7 @@
 * 2 6 50213 - Bryonia Berry Leaf (maker)
 
 *Matthew, "Moe", '10*
+*The one who screams removed empty hunger decrease and made berries invisible until picked.
 
 new: simp 2 6 50213 "moe_C2toDS_berries" 0 11 5000
 
@@ -67,7 +68,7 @@ scrp 2 8 50213 10
 
 	accg 0
 
-	attr 195
+	attr 211
 
 	elas 10
 
@@ -75,7 +76,7 @@ scrp 2 8 50213 10
 
 	tick rand 50 100
 
-	emit 6 .15
+*emit 6 .15
 
 endm
 
@@ -89,13 +90,17 @@ scrp 2 8 50213 9
 
 
 
-*you don't fall
+*you don't fall (actually yes you do but only on special occasions)
 
-*		doif ov00 ge rand 10 30
+		doif ov00 ge rand 50 100 and accg ne 4
 
-*			accg 4
+			emit 6 .15
 
-*		endi
+			attr 195
+
+			accg 4
+
+		endi
 
 
 
@@ -120,6 +125,10 @@ endm
 
 
 scrp 2 8 50213 5
+
+	emit 6 .15
+
+	attr 195
 
 	accg 4
 
@@ -157,7 +166,7 @@ scrp 2 8 50213 12
 
 *Hunger for Carbs Decrease*
 
-	chem 150 -.31
+*	chem 150 -.31
 
 *Prostaglandin*
 
@@ -194,4 +203,3 @@ scrx 2 8 50213 6
 scrx 2 8 50213 5
 
 scrx 2 8 50213 12
-

--- a/dev/Scripts/2.0_Cactus_Spikeocausius.cos
+++ b/dev/Scripts/2.0_Cactus_Spikeocausius.cos
@@ -5,7 +5,7 @@
 * 2 23 50207 - Spikeocausius Seed Launcher
 
 * Initial Conversion By Moe
-* Some Modifications By the one who screams i guess
+* Some Modifications By the one who screams i guess (dormant seed smell fix + something i don't remember -t1ws)
 * (if you worked on this file, feel free to add your name!)
 
 *Likes warm, desert conditions, produces flowers in springtime nights. 
@@ -31,7 +31,7 @@ reps rand 7 9
 	new: simp 2 5 50207 "moe_C2toDS_cacti" 13 32 rand 1000 2500
 
 	pose 6
-	
+
 	bhvr 11
 
 	setv va00 rand 7556 7750
@@ -51,7 +51,7 @@ reps rand 5 7
 	new: simp 2 5 50207 "moe_C2toDS_cacti" 13 32 rand 1000 2500
 
 	pose 6
-	
+
 	bhvr 11
 
 	setv va00 rand 6260 6650
@@ -71,7 +71,7 @@ scrp 2 23 50207 10
 
 	elas 10
 
-*BHVR
+	bhvr 9
 
 	fric 65
 
@@ -127,7 +127,9 @@ endm
 
 scrp 2 23 50207 1
 
-stim writ from 90 1
+	lock
+
+	stim writ from 90 1
 
 	reps rand 5 7
 
@@ -200,6 +202,16 @@ stim writ from 90 1
 	retn
 
 
+
+endm
+
+scrp 2 23 50207 3
+
+	stim writ from 92 1
+
+	snde "hit_"
+
+	velo rand -2 2 rand -10 -5
 
 endm
 
@@ -368,6 +380,9 @@ scrp 2 3 50207 9
 			show 0
 
 			bhvr 0
+
+*Stop emitting carb smell so you don't confuse creatures. -T1WS
+			emit 7 0
 
 			attr 209
 
@@ -547,9 +562,9 @@ endm
 
 scrp 2 5 50207 1
 
-	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -560,9 +575,9 @@ endm
 
 
 scrp 2 5 50207 2
- 	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -572,9 +587,9 @@ endm
 
 
 scrp 2 5 50207 3
-	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -658,6 +673,8 @@ next
 
 scrx 2 23 50207 1
 
+scrx 2 23 50207 3
+
 
 
 enum 2 3 50207
@@ -681,4 +698,3 @@ enum 2 5 50207
 	kill targ
 
 next
-

--- a/dev/Scripts/2.0_Cactus_Spinnomosa.cos
+++ b/dev/Scripts/2.0_Cactus_Spinnomosa.cos
@@ -5,7 +5,7 @@
 * 2 23 50206 - Spinnomosa Seed Launcher
 
 *Likes warm, desert conditions, grows all year round (except winter) in the mornings, produces flowers at night. 
-
+*The one who screams stopped dormant seeds emitting a smell.
 
 new: comp 2 23 50206 "moe_C2toDS_cacti" 8 72 rand 1000 2500
 
@@ -22,7 +22,7 @@ mvsf 7770 47950
 reps rand 7 9
 
 	new: simp 2 5 50206 "moe_C2toDS_cacti" 20 0 rand 1000 2500
-	
+
 	bhvr 11
 
 	pose 9
@@ -42,7 +42,7 @@ repe
 reps rand 5 7
 
 	new: simp 2 5 50206 "moe_C2toDS_cacti" 20 0 rand 1000 2500
-	
+
 	bhvr 11
 
 	pose 9
@@ -64,7 +64,7 @@ scrp 2 23 50206 10
 
 	elas 10
 
-*BHVR
+	bhvr 9
 
 	fric 65
 
@@ -116,7 +116,7 @@ endm
 
 scrp 2 23 50206 1
 
-stim writ from 90 1
+	stim writ from 90 1
 
 	reps rand 5 7
 
@@ -155,6 +155,17 @@ stim writ from 90 1
 	retn
 
 
+
+endm
+
+
+scrp 2 23 50206 3
+
+	stim writ from 92 1
+
+	snde "hit_"
+
+	velo rand -2 2 rand -10 -5
 
 endm
 
@@ -259,7 +270,7 @@ scrp 2 3 50206 9
 *Create Spinnomosa
 
 			new: simp 2 5 50206 "moe_C2toDS_cacti" 20 0 rand 1000 2500
-			
+
 			bhvr 11
 
 			doif va02 eq 1
@@ -322,6 +333,9 @@ scrp 2 3 50206 9
 
 			bhvr 0
 
+*Stop emitting carb smell so you don't confuse creatures. -T1WS
+			emit 7 0
+
 			attr 209
 
 			tick 1200
@@ -342,11 +356,11 @@ scrp 2 3 50206 9
 
 * Removing Wind Interaction
 
-	*	setv va00 lorp grap posx posy 19 0
+*	setv va00 lorp grap posx posy 19 0
 
 
 
-	*	setv va01 torx va00
+*	setv va01 torx va00
 
 
 * make wind random instead
@@ -509,11 +523,11 @@ endm
 
 
 scrp 2 5 50206 1
-inst
+	inst
 *stim norns
-	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -562,11 +576,11 @@ inst
 endm
 
 scrp 2 5 50206 2
-inst
+	inst
 *stim norns
-	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -582,11 +596,11 @@ inst
 endm
 
 scrp 2 5 50206 3
-inst
+	inst
 *stim norns
-	targ from 
+	targ from
 	doif fmly eq 4
-	
+
 		stim writ from 83 1
 	endi
 	targ ownr
@@ -689,6 +703,8 @@ enum 2 23 50206
 next
 
 scrx 2 23 50206 1
+
+scrx 2 23 50206 3
 
 
 

--- a/dev/Scripts/2.0_Cantharis_Berry.cos
+++ b/dev/Scripts/2.0_Cantharis_Berry.cos
@@ -4,6 +4,7 @@
 * 2 8 50207 - Cantharis Berry
 
 *Matthew, "Moe", '10*
+*The one who screams removed empty hunger decrease, made berries invisible until picked, and shortened lifespan.
 
 new: simp 2 6 50207 "moe_C2toDS_berries" 0 0 5000
 
@@ -55,7 +56,7 @@ scrp 2 8 50207 10
 
 	accg 0
 
-	attr 195
+	attr 211
 
 	elas 10
 
@@ -63,7 +64,7 @@ scrp 2 8 50207 10
 
 	tick rand 50 100
 
-	emit 6 .15
+*emit 6 .15
 
 endm
 
@@ -75,17 +76,23 @@ scrp 2 8 50207 9
 
 		addv ov00 1
 
-		doif ov00 ge rand 10 50 and accg ne 4
+		doif ov00 ge rand 20 40 and accg ne 4
 
 			accg 4
 
+			attr 195
+
+			emit 6 .15
+
 			velo rand -5 5 0
+
+			setv ov00 0
 
 		endi
 
 
 
-		doif ov00 ge rand 125 150
+		doif ov00 ge rand 10 20 and accg eq 4
 
 			kill targ
 
@@ -115,7 +122,17 @@ endm
 
 scrp 2 8 50207 5
 
+	doif accg ne 4
+
+		setv ov00 0
+
+	endi
+
 	accg 4
+
+	attr 195
+
+	emit 6 .15
 
 endm
 
@@ -141,15 +158,15 @@ scrp 2 8 50207 12
 
 *Hunger for Fat 50*
 
-	chem 151 -.23
+*chem 151 -.23
 
 *Hunger for Starch 50*
 
-	chem 150 -.19
+*chem 150 -.19
 
 *Hunger for Protein 50*
 
-	chem 149 -.23
+*chem 149 -.23
 
 *Fat* 60
 

--- a/dev/Scripts/2.0_Deathcap_Mushroom.cos
+++ b/dev/Scripts/2.0_Deathcap_Mushroom.cos
@@ -5,6 +5,7 @@
 
 * Verm here, to make the detritus edible/toxic friendly! And I guess generally a bit too...
 * Aiko fixed some syntax weirdnesses
+* The one who screams made spores invisible to creatures
 
 reps rand 1 2
 
@@ -67,7 +68,7 @@ repe
 
 scrp 2 3 50218 10
 
-	attr 198
+	attr 214
 
 	elas 0
 
@@ -86,7 +87,7 @@ endm
 
 
 scrp 2 3 50218 12
-inst
+	inst
 	stim writ from 77 0.7
 	snde "reat"
 
@@ -372,7 +373,7 @@ scrp 2 10 50207 10
 	aero 2
 
 	attr 194
-	
+
 	bhvr 48
 
 	tick rand 500 1000
@@ -510,36 +511,36 @@ endm
 * Deathcap detritus timer script
 
 scrp 2 10 50207 9
-inst
-doif carr eq null
-	doif pose lt 2
+	inst
+	doif carr eq null
+		doif pose lt 2
 
-		setv va00 pose
+			setv va00 pose
 
-		addv va00 1
+			addv va00 1
 
-		pose va00
+			pose va00
 
+		endi
+
+		doif pose eq 2
+
+			kill ownr
+
+		endi
 	endi
-
-	doif pose eq 2
-
-		kill ownr
-
-	endi
-endi
 endm
 
 * Deathcap detritus eat script
 scrp 2 10 50207 12
-inst
-stim writ from 81 1
+	inst
+	stim writ from 81 1
 endm
 * Deathcap top timer script
 
 scrp 2 20 50200 9
-inst
-attr 208
+	inst
+	attr 208
 	wait rand 2000 5000
 
 	kill ownr
@@ -551,10 +552,10 @@ endm
 * Deathcap top eat script
 
 scrp 2 20 50200 12
-inst
+	inst
 * Insert nasty chemicals here! 
 ** I'm just goign to stim writ a good amount of detritus - Verm
-	
+
 	stim writ from 81 1.5
 	stim writ from 82 0
 	attr 208
@@ -606,4 +607,3 @@ scrx 2 20 50200 10
 scrx 2 20 50200 9
 
 scrx 2 20 50200 12
-

--- a/dev/Scripts/2.0_Foxfire_Tree.cos
+++ b/dev/Scripts/2.0_Foxfire_Tree.cos
@@ -5,6 +5,8 @@
 * 2 8 50209 - Foxfire Berry
 * 2 8 50210 - Winter Foxfire Berry
 
+*The one who screams made the berries invisible while still on the tree.
+
 new: simp 2 6 50209 "moe_C2toDS_humming" 1 59 0
 
 mvto 4677 48422
@@ -277,13 +279,13 @@ scrp 2 8 50209 10
 
 	fric 45
 
-	attr 195
+	attr 211
 
 	tick 500
 
 	bhvr 51
 
-	emit 6 .15
+*	emit 6 .15
 
 endm
 
@@ -301,13 +303,13 @@ scrp 2 8 50210 10
 
 	fric 45
 
-	attr 195
+	attr 211
 
 	tick 500
 
 	bhvr 51
 
-	emit 6 .15
+*	emit 6 .15
 
 endm
 
@@ -319,7 +321,11 @@ endm
 
 scrp 2 8 50209 4
 
+	attr 195
+
 	accg 5
+
+	emit 6 .15
 
 endm
 
@@ -327,7 +333,11 @@ endm
 
 scrp 2 8 50210 4
 
+	attr 195
+
 	accg 5
+
+	emit 6 .15
 
 endm
 
@@ -461,7 +471,11 @@ scrp 2 8 50209 9
 
 	doif accg eq 0
 
+		attr 195
+
 		accg 5
+
+		emit 6 .15
 
 		tick 5000
 
@@ -485,7 +499,11 @@ scrp 2 8 50210 9
 
 	doif accg eq 0
 
+		attr 195
+
 		accg 5
+
+		emit 6 .15
 
 		tick 5000
 
@@ -546,7 +564,3 @@ enum 1 26 50210
 	kill targ
 
 next
-
-
-
-

--- a/dev/Scripts/2.0_Ledum_Berries.cos
+++ b/dev/Scripts/2.0_Ledum_Berries.cos
@@ -4,6 +4,8 @@
 
 *Matthew, "Moe", '10*
 
+*The one who screams stopped the berries emitting protein smell.
+
 new: simp 2 6 50203 "moe_C2toDS_berries" 0 0 rand 1000 3000
 
 attr 16
@@ -112,7 +114,7 @@ scrp 2 20 50203 10
 
 	tick rand 50 100
 
-	emit 6 .15
+*emit 6 .15
 
 endm
 

--- a/dev/Scripts/2.0_Little_Mushrooms.cos
+++ b/dev/Scripts/2.0_Little_Mushrooms.cos
@@ -672,6 +672,22 @@ scrp 2 24 50208 1
 
 	lock
 
+	etch 2 4 50201
+
+		addv va02 1
+
+	next
+
+	doif ov00 eq 0 and va02 gt 0
+
+		snde "buzz"
+
+		stop
+
+		unlk
+
+	endi
+
 	sndc "m_a7"
 
 	anim [0 1 2 3 4 5 6 7 8 9 10]

--- a/dev/Scripts/2.0_Masham_Berries.cos
+++ b/dev/Scripts/2.0_Masham_Berries.cos
@@ -4,6 +4,7 @@
 
 
 *Matthew, "Moe", '10*
+*The one who screams removed empty hunger decrease and made berries invisible until picked.
 
 new: simp 2 6 50212 "moe_C2toDS_berries" 0 0 5000
 
@@ -41,13 +42,13 @@ scrp 2 6 50212 9
 
 		perm 55
 
-		bhvr 49
+		bhvr 48
 
 		mvsf va01 va02
 
 		accg 0
 
-		attr 195
+		attr 211
 
 		elas 10
 
@@ -63,7 +64,7 @@ endm
 
 scrp 2 8 50212 10
 
-	emit 6 .15
+*emit 6 .15
 
 endm
 
@@ -75,17 +76,23 @@ scrp 2 8 50212 9
 
 		addv ov00 1
 
-		doif ov00 ge rand 10 50 and accg ne 4
+		doif ov00 ge rand 20 40 and accg ne 6
 
-			accg 4
+				accg 6
+
+	attr 195
+
+	emit 6 .15
 
 			velo rand -5 5 0
+
+			setv ov00 0
 
 		endi
 
 
 
-		doif ov00 ge rand 125 150
+		doif ov00 ge rand 10 20 and accg eq 6
 
 			kill targ
 
@@ -111,15 +118,18 @@ scrp 2 8 50212 4
 
 endm
 
-
-
 scrp 2 8 50212 5
 
-	accg 6
+	doif accg ne 6
+		setv ov00 0
+	endi
+		accg 6
+
+	attr 195
+
+	emit 6 .15
 
 endm
-
-
 
 scrp 2 8 50212 6
 
@@ -141,15 +151,15 @@ scrp 2 8 50212 12
 
 *Hunger for Fat *
 
-	chem 151 -.31
+*chem 151 -.31
 
 *Hunger for Starch *
 
-	chem 150 -.39
+*chem 150 -.39
 
 *Hunger for Protein *
 
-	chem 149 -.27
+*chem 149 -.27
 
 *Fat* 80
 
@@ -170,7 +180,6 @@ scrp 2 8 50212 12
 	kill targ
 
 endm
-
 
 rscr
 

--- a/dev/Scripts/2.0_Nuts.cos
+++ b/dev/Scripts/2.0_Nuts.cos
@@ -3,7 +3,8 @@
 * 2 23 50202 - Nut Vendor
 
 *Initial Conversion By Moe
-* Some Modifications By the one who screams i guess
+* Survivability edits by the one who screams i guess
+*Also tweaked lifespan a little to be more in line with C2 nuts (more prolific than tomatoes)...
 * (if you worked on this file, feel free to add your name!)
 
 reps rand 5 7
@@ -260,7 +261,8 @@ scrp 2 3 50202 9
 
 		esee 2 4 50202
 
-			doif targ ne null
+*don't factor old dying plants in the population check pls -t1ws
+			doif targ ne null and ov10 lt 30
 
 				addv va06 1
 
@@ -468,7 +470,7 @@ scrp 2 4 50202 9
 
 
 
-	doif ov04 ge 42 and ov04 lt 45
+	doif ov04 ge 30 and ov04 lt 39
 
 		inst
 
@@ -528,7 +530,7 @@ scrp 2 4 50202 9
 
 
 
-	doif ov04 ge 50
+	doif ov04 ge 40
 
 		lock
 
@@ -940,6 +942,8 @@ scrp 2 3 50202 12
 
 *Make it invisible so that creatures don't destroy it.
 		attr 211
+		*And stop smelling.
+			emit 7 0
 
 	elif ov09 eq 1
 
@@ -1055,7 +1059,7 @@ enum 2 4 50202
 next
 
 enum 2 23 50202
-kill targ
+	kill targ
 next
 
 scrx 2 23 50202 10

--- a/dev/Scripts/2.0_Pears.cos
+++ b/dev/Scripts/2.0_Pears.cos
@@ -6,6 +6,8 @@
 
 * Verm here just to check things...they already got the basics covered.
 * Aiko here to fix the weird seed attr drama
+* Scream here stopping dormant seeds from emitting carb smell 
+* and letting creatures eat pears directly off the plant.
 
 new: comp 2 23 50204 "moe_C2toDS_pear" 8 0 rand 500 2500
 
@@ -356,27 +358,30 @@ scrp 2 3 50204 9
 			show 0
 
 			bhvr 0
-			
+
+*stop smelling when dormant pls
+			emit 7 0
+
 * this attr change was throwing errors if the seed somehow ended up 
 * ouside the room system...
 * Why the seeds were ending up outside the room system in the first place
 * might still need to be addressed.
 			targ ownr
-			
+
 			inst
 
-			*this is so rare I can't seem to reproduce it but I'm
-			* going to hope this works.
+*this is so rare I can't seem to reproduce it but I'm
+* going to hope this works.
 			doif tmvt posl post eq 0
-			
+
 				kill ownr
-				
+
 				stop
-			
+
 			endi
 
 			attr 209
-			
+
 			slow
 
 		endi
@@ -713,7 +718,7 @@ scrp 2 7 50204 9
 
 			attr 231
 
-			bhvr 32
+			bhvr 48
 
 		endi
 
@@ -725,7 +730,7 @@ scrp 2 7 50204 9
 
 			attr 231
 
-			bhvr 32
+			bhvr 48
 
 		endi
 
@@ -737,7 +742,7 @@ scrp 2 7 50204 9
 
 			attr 231
 
-			bhvr 32
+			bhvr 48
 
 		endi
 
@@ -1425,7 +1430,7 @@ endm
 
 
 scrp 2 10 50204 12
-inst
+	inst
 ** oh hey they already made this - Verm
 	stim writ from 81 1
 

--- a/dev/Scripts/2.0_Pulsatilla_Berry.cos
+++ b/dev/Scripts/2.0_Pulsatilla_Berry.cos
@@ -6,6 +6,7 @@
 
 
 *Matthew, "Moe", '10*
+*The one who screams removed empty hunger decrease and shortened lifespan. (Doesn't need invisibility.)
 
 new: simp 2 6 50202 "moe_C2toDS_berries" 0 0 5000
 
@@ -31,15 +32,15 @@ scrp 2 6 50202 9
 
 		doif va00 eq 0
 
-			setv va01 rand 3773 3903
+			setv va01 rand 3790 3890
 
-			setv va02 rand 48324 48398
+			setv va02 rand 48350 48386
 
 		elif va00 eq 1
 
-			setv va01 rand 3702 3840
+			setv va01 rand 3730 3810
 
-			setv va02 rand 48147 48218
+			setv va02 rand 48165 48200
 
 		endi
 
@@ -96,12 +97,13 @@ scrp 2 8 50202 9
 			accg 4
 
 			velo rand -5 5 0
+			setv ov00 0
 
 		endi
 
 
 
-		doif ov00 ge rand 125 150
+		doif ov00 ge rand 5 10 and accg eq 4
 
 			kill targ
 
@@ -131,6 +133,12 @@ endm
 
 scrp 2 8 50202 5
 
+	doif accg ne 4
+
+		setv ov00 0
+
+	endi
+
 	accg 4
 
 endm
@@ -157,15 +165,15 @@ scrp 2 8 50202 12
 
 *Hunger for Fat 50*
 
-	chem 151 -.23
+*chem 151 -.23
 
 *Hunger for Starch 50*
 
-	chem 150 -.19
+*chem 150 -.19
 
 *Hunger for Protein 50*
 
-	chem 149 -.23
+*chem 149 -.23
 
 *Fat* 60
 

--- a/dev/Scripts/2.0_Tomatoes.cos
+++ b/dev/Scripts/2.0_Tomatoes.cos
@@ -2,7 +2,7 @@
 * 2 8 50200 - Tomato
 
 * Initial Conversion By Moe
-* Some Modifications By the one who screams i guess
+* Instinct friendliness and survivability edits by the one who screams i guess
 * (if you worked on this file, feel free to add your name!)
 
 reps rand 5 7
@@ -461,7 +461,7 @@ scrp 2 8 50200 10
 
 	endi
 
-	emit 6 .015
+	emit 6 0.15
 
 endm
 
@@ -636,8 +636,8 @@ scrp 2 8 50200 9
 
 
 		esee 2 4 50200
-
-			doif targ ne null
+*don't factor old dying plants in the population check pls -t1ws
+			doif targ ne null and ov10 lt 40
 
 				addv va25 1
 
@@ -720,6 +720,7 @@ scrp 2 8 50200 12
 		base 17
 		pose 0
 		attr 211
+		emit 6 0
 	else
 		kill ownr
 	endi

--- a/dev/Scripts/2.0_Trumpet.cos
+++ b/dev/Scripts/2.0_Trumpet.cos
@@ -5,6 +5,7 @@
 * 2 23 50203 - Trumpet Vendor
 
 * Verm here, making detritus edible/toxic friendly!
+* The one who screams made dormant seeds invisible to creatures and made them stop emitting smell
 
 reps rand 5 7
 
@@ -180,9 +181,9 @@ scrp 2 3 50203 12
 
 	targ from
 
-	chem 5 .19
+	*chem 5 .19
 
-	chem 10 .19
+	*chem 10 .19
 
 	snde "chwp"
 
@@ -393,16 +394,19 @@ scrp 2 3 50203 9
 
 			doif sean ne 3 or rand 0 3 eq 0
 
-			    kill ownr
+				kill ownr
 
-            endi
+			endi
 		else
 
 			show 0
 
+*stop smelling when dormant pls -t1ws
+			emit 7 0
+
 			bhvr 0
 
-			attr 193
+			attr 209
 
 			tick rand 1000 1600
 
@@ -1202,7 +1206,7 @@ endm
 
 
 scrp 2 10 50203 9
-inst
+	inst
 	doif carr eq null
 
 		altr -1 2 .005
@@ -1224,7 +1228,7 @@ endm
 
 
 scrp 2 10 50203 12
-inst
+	inst
 	lock
 
 	stim writ from 81 1

--- a/dev/Scripts/2.1_Punching_Bag.cos
+++ b/dev/Scripts/2.1_Punching_Bag.cos
@@ -69,11 +69,15 @@ scrp 2 21 50203 1
 
 *Added pointer smack animations to fit the direction hit. -- Moe 
 
-		targ pntr
+		doif from eq pntr
 
-		anim [4 4 5 5 0]
+			targ pntr
+
+			anim [4 4 5 5 0]
 
 		targ ownr
+		
+		endi
 
 		anim [10 11 12 13 14 15 16 17 0]
 
@@ -82,12 +86,16 @@ scrp 2 21 50203 1
 		wait 20
 
 	else
+	
+	doif from eq pntr
 
 		targ pntr
 
 		anim [10 10 11 11 12 12 0]
 
 		targ ownr
+		
+		endi
 
 		anim [1 2 3 4 5 6 7 8 9 0]
 
@@ -208,8 +216,6 @@ enum 2 21 50203
 	kill targ
 
 next
-
-
 
 
 

--- a/dev/Scripts/2.2_Anemone.cos
+++ b/dev/Scripts/2.2_Anemone.cos
@@ -197,11 +197,8 @@ scrp 2 15 50208 5
 
 endm
 
+rscr
 
 enum 2 15 50208
-
 	kill targ
-
 next
-
-

--- a/dev/Scripts/2.2_Bees.cos
+++ b/dev/Scripts/2.2_Bees.cos
@@ -21,10 +21,6 @@ mvsf va00 49675
 
 setv name "type" 1
 
-*Make it interactable and change its category
-bhvr 1
-cato 23
-
 cabn 10 0 60 50
 
 mira rand 0 1
@@ -357,6 +353,12 @@ scrp 2 17 50200 10
 
 		accg 4
 
+		rnge 500
+		
+		bhvr 1
+		
+		cato 23
+
 	endi
 
 	tick 1
@@ -367,91 +369,109 @@ endm
 
 scrp 2 17 50200 9
 
+	doif name "type" eq 1
+
+		esee 2 11 50204
+
+			addv va00 1
+
+		next
+
+		doif va00 ge 10
+
+			attr 732
+
+		else
+
+			attr 716
+
+		endi
+
+	else
+
+		doif time eq 3 or time eq 4 and 0 eq 1
+
+			stop
+
+		endi
 
 
-	doif time eq 3 or time eq 4 and 0 eq 1
 
-		stop
+		doif sean eq 3 and 0 eq 1
 
-	endi
+			stop
 
-
-
-	doif sean eq 3 and 0 eq 1
-
-		stop
-
-	endi
+		endi
 
 
 
-	tick rand 500 700
+		tick rand 500 700
 
 *look for bees
 
-	enum 2 14 50200
+		enum 2 14 50200
 
-		inst
+			inst
 
-		doif targ ne null
+			doif targ ne null
 
 *make sure their hive is you or else you don't want to see them
 
-			doif ov05 eq ownr
+				doif ov05 eq ownr
 
-				addv va00 1
+					addv va00 1
+
+				endi
+
+			endi
+
+			slow
+
+		next
+
+		targ ownr
+
+		doif va00 lt 5
+
+			setv va00 posx
+
+			setv va01 posy
+
+			inst
+
+			new: simp 2 14 50200 "moe_C2toDS_hive" 4 26 rand 2000 5000
+
+			seta ov05 ownr
+
+			mvsf va00 va01
+
+			slow
+
+			targ ownr
+
+		endi
+
+*ov08 is honey, which dictates your size.
+
+		doif name "type" eq 0
+
+			doif ov08 ge 50 and ov08 lt 51
+
+				base 6
+
+			elif ov08 ge 100 and ov08 lt 101
+
+				base 12
+
+			elif ov08 ge 150 and ov08 lt 151
+
+				base 18
 
 			endi
 
 		endi
 
-		slow
-
-	next
-
-	targ ownr
-
-	doif va00 lt 5
-
-		setv va00 posx
-
-		setv va01 posy
-
-		inst
-
-		new: simp 2 14 50200 "moe_C2toDS_hive" 4 26 rand 2000 5000
-
-		seta ov05 ownr
-
-		mvsf va00 va01
-
-		slow
-
-		targ ownr
-
 	endi
-
-*ov08 is honey, which dictates your size.
-
-	doif name "type" eq 0
-
-		doif ov08 ge 50 and ov08 lt 51
-
-			base 6
-
-		elif ov08 ge 100 and ov08 lt 101
-
-			base 12
-
-		elif ov08 ge 150 and ov08 lt 151
-
-			base 18
-
-		endi
-
-	endi
-
-
 
 endm
 

--- a/dev/Scripts/2.2_Coral.cos
+++ b/dev/Scripts/2.2_Coral.cos
@@ -283,7 +283,7 @@ scrp 2 15 50212 9
 
 		doif va03 ge 2
 
-*setv ov14 1
+			setv ov14 1
 
 			stop
 
@@ -626,7 +626,7 @@ scrp 2 3 50227 12
 	snde "reat"
 
 
-		stim writ from 77 .25
+	stim writ from 77 .25
 
 
 	kill ownr
@@ -764,7 +764,7 @@ endm
 *timer
 
 scrp 2 10 50212 9
-inst
+	inst
 	kill ownr
 
 endm
@@ -773,8 +773,8 @@ endm
 
 scrp 2 10 50212 12
 
-		stim writ from 81 1
-		
+	stim writ from 81 1
+
 endm
 
 rscr
@@ -866,5 +866,3 @@ scrx 2 3 50227 6
 scrx 2 3 50227 9
 
 scrx 2 3 50227 12
-
-

--- a/dev/Scripts/3.0_Lifts.cos
+++ b/dev/Scripts/3.0_Lifts.cos
@@ -474,6 +474,8 @@ scrp 3 1 50200 10
 
 	cabp 0
 
+	seta ov05 null
+
 *cabin can't hold more than 40 creatures
 
 	cabw 40
@@ -1546,6 +1548,7 @@ endm
 scrp 3 1 50200 1
 	lock
 	inst
+	seta ov05 from
 	gsub movelift
 
 	subr movelift
@@ -1575,6 +1578,7 @@ endm
 scrp 3 1 50200 2
 	lock
 	inst
+	seta ov05 from
 	gsub movelift
 
 	subr movelift
@@ -1677,7 +1681,21 @@ scrp 3 1 50200 9
 
 		doif posb lt va01
 
-			gpas 4 0 0 0
+			doif crea ov05 eq 1
+
+				doif touc ownr ov05 eq 1
+
+					spas ownr ov05
+
+				endi
+
+			else
+
+				gpas 4 0 0 0
+
+			endi
+
+			seta ov05 null
 
 			doif ov04 eq 1
 
@@ -1705,7 +1723,21 @@ scrp 3 1 50200 9
 
 		elif posb gt va01
 
-			gpas 4 0 0 0
+			doif crea ov05 eq 1
+
+				doif touc ownr ov05 eq 1
+
+					spas ownr ov05
+
+				endi
+
+			else
+
+				gpas 4 0 0 0
+
+			endi
+
+			seta ov05 null
 
 			doif ov04 eq 1
 
@@ -1898,6 +1930,8 @@ scrp 2 12 50200 2
 
 		targ ov00
 
+		seta ov05 from
+
 		doif vtos name "current level" ne mv01
 
 			adds name "call list" mv01
@@ -1959,6 +1993,8 @@ scrp 2 12 50200 1
 		inst
 
 		targ ov00
+
+		seta ov05 from
 
 		doif vtos name "current level" ne mv01
 


### PR DESCRIPTION
-Toxic ledum berries no longer emit protein smell.
-Cactus, pear, and trumpet seeds no longer emit a smell when dormant. Dormant trumpet seeds are now invisible to creatures.
-Deathcap spores are now invisible to creatures.
-Nuts and tomatoes no longer factor old, dying plants in their population check. Nuts are now more prolific and have a slightly shorter lifespan to match their C2 counterpart.
-Bitten nuts and tomatoes no longer emit a smell.
-Nerfed the startle intensity and range of thunder.
-The hand no longer animates when creatures use the punching bag.
-Coral now dies after seeding.
-Several patch fruits are now invisible until they fall from the vine.
-Masham, cantharis, and pulsatilla berries now rot more quickly so that they spend more time making the parent plant look nice and less time in awkward piles on the ground.
-Tweaked pulsatilla berry patch placement.
-Both types of cactus seed dispensers can now be pushed and hit by creatures.
-Mushroom dispensers will no longer create a mushroom patch if they are already on top of one.
-Dustdevils can no longer carry mushrooms to prevent excessive formation of new patches.
-The beehive in the garden now becomes invisible to creatures if there are more than 10 jars of honey nearby.
-Lifts will now only pick up the creature that activated them unless activated by the Hand, in which case they will pick up all nearby creatures.