### PR TITLE
Update .gitattributes with Creatures' file formats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,14 @@
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
 *.cos text eol=crlf
+*.att text eol=crlf
+*.catalogue text eol=crlf
+*.ps text eol=crlf
+
+*.blk binary
+*.c16 binary
+*.s16 binary
+*.spr binary
+*.agents binary
+*.agent binary
+*.cob binary


### PR DESCRIPTION
Git tried to diff a  `.agents` file, so I decided to add it along with a few other binary and text formats to .gitattributes.

Might be overkill though