### PR TITLE
Fix `invalid targ` error on dying tomato check

### DIFF
--- a/dev/Scripts/2.0_Tomatoes.cos
+++ b/dev/Scripts/2.0_Tomatoes.cos
@@ -634,6 +634,7 @@ scrp 2 8 50200 9
 		endi
 
 
+		inst
 
 		esee 2 4 50200
 *don't factor old dying plants in the population check pls -t1ws
@@ -644,6 +645,8 @@ scrp 2 8 50200 9
 			endi
 
 		next
+
+		slow
 
 		targ ownr
 


### PR DESCRIPTION
Tomatoes error out when checking the OV10 variable of a tomato that may have been `kill`'d while inside the `doif` check.

This fix simply wraps the `ESEE`..`NEXT` with an `inst`  and `slow` which seems to prevent this error.

Fixes #63