### PR TITLE
Chimes + Helicopter fixes

### DIFF
--- a/dev/Scripts/2.1_Chimes.cos
+++ b/dev/Scripts/2.1_Chimes.cos
@@ -54,8 +54,13 @@ endm
 *_P2_ is which chime was activated
 scrp 2 21 50205 1000
 
+*Animate pointer click
+	doif _p1_ = pntr
+		targ _p1_
+		anim [0 1 0]
+		targ ownr
 *Stimulate the creature with "Played with toy"
-	doif crea _p1_ = 1
+	else
 		stim writ _p1_ 97 1
 	endi
 
@@ -77,7 +82,7 @@ scrp 2 21 50205 1000
 	else
 		snde "vib6"
 	endi
-	
+
 endm
 
 
@@ -97,7 +102,9 @@ endm
 scrp 2 21 50205 3
 	sndc "hit_"
 	velo rand -3 3 rand -8 -12
-	stim writ from 92 1
+
+*Stimulate the creature with "Played with toy"
+	stim writ from 97 1
 endm
 
 

--- a/dev/Scripts/3.0_Helicopter.cos
+++ b/dev/Scripts/3.0_Helicopter.cos
@@ -6,7 +6,13 @@
 new: vhcl 3 2 50206 "moe_C2toDS_sola" 14 2 1000
 
 mvsf 6480 47986
-cmrt 0
+
+
+
+
+*creation script
+
+scrp 3 2 50206 10
 
 
 pat: butt 1 "moe_C2toDS_sola" 32 2 180 48 0 [] 1000 0
@@ -19,6 +25,17 @@ pat: butt 2 "moe_C2toDS_sola" 34 2 257 175 0 [] 1001 0
 
 pat: butt 3 "moe_C2toDS_sola" 36 2 102 176 0 [] 1002 0
 
+
+*C2 framerate
+
+frat 2
+part 1
+frat 2
+part 2
+frat 2
+part 3
+frat 2
+part 0
 
 
 *pat: dull 4 "moe_C2toDS_sola" 0 0 0 0
@@ -34,7 +51,6 @@ cabp -10
 cabn 125 75 270 200
 
 
-scrp 3 2 50206 10
 
 	attr 215
 
@@ -46,6 +62,8 @@ scrp 3 2 50206 10
 *... but it also stops it spawning, so I guess we gotta edit the map...
 *	perm 51
 
+	perm 50
+
 	setv ov03 0
 
 	setv ov04 19.5
@@ -53,6 +71,8 @@ scrp 3 2 50206 10
 endm
 
 
+
+*activate 1
 
 scrp 3 2 50206 1
 
@@ -67,6 +87,7 @@ endm
 
 
 
+*timer
 
 scrp 3 2 50206 9
 
@@ -174,7 +195,6 @@ scrp 3 2 50206 1001
 
 	targ ownr
 
-	frat 2
 
 
 
@@ -214,8 +234,6 @@ scrp 3 2 50206 1001
 
 		over
 
-		frat 1
-
 		anim [ 6 7 8 9 255]
 
 		inst
@@ -231,6 +249,14 @@ scrp 3 2 50206 1001
 		pat: butt 3 "moe_C2toDS_sola" 37 2 249 176 0 [] 1002 0
 
 
+*C2 framerate
+
+		part 1
+		frat 2
+		part 2
+		frat 2
+		part 3
+		frat 2
 
 *pat: dull 4 "moe_C2toDS_sola" 1 0 0 10
 
@@ -262,7 +288,7 @@ scrp 3 2 50206 1001
 
 		pat: kill 3
 
-		pat: kill 4
+*		pat: kill 4
 
 
 
@@ -271,8 +297,6 @@ scrp 3 2 50206 1001
 		anim [1 8 13 12 11 10]
 
 		over
-
-		frat 1
 
 		anim [ 2 3 4 5 255]
 
@@ -291,6 +315,15 @@ scrp 3 2 50206 1001
 		pat: butt 3 "moe_C2toDS_sola" 36 2 102 176 0 [] 1002 0
 
 
+*C2 framerate
+
+		part 1
+		frat 2
+		part 2
+		frat 2
+		part 3
+		frat 2
+		part 0
 
 *pat: dull 4 "moe_C2toDS_sola" 0 0 0 10
 
@@ -322,7 +355,6 @@ scrp 3 2 50206 1002
 
 	targ ownr
 
-	frat 2
 
 
 
@@ -360,8 +392,6 @@ scrp 3 2 50206 1002
 
 *over
 
-		frat 1
-
 		anim [ 2 3 4 5 255]
 
 
@@ -377,6 +407,15 @@ scrp 3 2 50206 1002
 		pat: butt 3 "moe_C2toDS_sola" 36 2 102 176 0 [] 1002 0
 
 
+*C2 framerate
+
+		part 1
+		frat 2
+		part 2
+		frat 2
+		part 3
+		frat 2
+		part 0
 
 	else
 
@@ -410,7 +449,6 @@ scrp 3 2 50206 1002
 
 *over
 
-		frat 1
 
 		anim [ 6 7 8 9 255]
 
@@ -427,6 +465,15 @@ scrp 3 2 50206 1002
 		pat: butt 3 "moe_C2toDS_sola" 37 2 249 176 0 [] 1002 0
 
 
+*C2 framerate
+
+		part 1
+		frat 2
+		part 2
+		frat 2
+		part 3
+		frat 2
+		part 0
 
 	endi
 
@@ -438,9 +485,19 @@ scrp 3 2 50206 1002
 
 endm
 
+
+*goodbye
+
 rscr
+
 enum 3 2 50206
 
 	kill targ
 
 next
+
+scrx 3 2 50206 1
+scrx 3 2 50206 9
+scrx 3 2 50206 1000
+scrx 3 2 50206 1001
+scrx 3 2 50206 1002


### PR DESCRIPTION
Helicopter Fixes

-Removed CMRT 0 from install script (d'oh)
-Moved most of the install script stuff to the creation script.
-Added back missing PERM command.
-FRAT is now set to 2 when creating the helicopter/parts, instead of before animating. It is also consistently 2 instead of sometimes 1, now.
-Added a proper remove script.


Chimes fixes

-Fixed the chimes hit script stimming "Hit machine" instead of "Played with toy" (d'oh)
-Pointer now animates when clicking the chimes (double d'oh)