### PR TITLE
Make lift button hittable

### DIFF
--- a/dev/Scripts/3.0_Lifts.cos
+++ b/dev/Scripts/3.0_Lifts.cos
@@ -4,7 +4,7 @@
 *//*Norn Burrow Lift*//*
 
 *Matthew, "Moe", '10*
-* Some Modifications By the one who screams i guess
+* Some Modifications By the one who screams i guess, Malkin
 * (if you worked on this file, feel free to add your name!)
 
 inst
@@ -1824,7 +1824,7 @@ scrp 2 12 50200 10
 
 	attr 4
 
-	bhvr 3
+	bhvr 11
 
 	setv ov02 0
 
@@ -2045,6 +2045,22 @@ scrp 2 12 50200 1
 endm
 
 
+*Button hit script
+scrp 2 12 50200 3
+*Instantaneously
+    inst
+*Stimulate with "I have hit machine"
+    stim writ from 92 1
+*Blink the call button light on and off
+    anim [0 1 255]
+*Play a buzzing sound (included by default with C3 and DS)
+    snde "buzz"
+*Wait until the buzzing sound is over
+    wait 7
+*Resume a ready-to-serve pose.
+    pose 0
+endm 
+
 
 scrp 2 12 50200 1000
 
@@ -2093,6 +2109,7 @@ scrx 3 1 50200 9
 
 scrx 2 12 50200 10
 scrx 2 12 50200 1001
+scrx 2 12 50200 3
 scrx 2 12 50200 2
 scrx 2 12 50200 1
 scrx 2 12 50200 1000


### PR DESCRIPTION
Change BHVR in call button script 10 to 11 (push, pull and hit) and add hit script for the call buttons, which stimulates with 'I have hit machine', does not call the lift, and makes the call button light blink, and emit a forbidding buzzing sound.