### PR TITLE
Fix Queue Killing itself during a LOCKed Loop

### DIFF
--- a/dev/Scripts/3.0_Boat.cos
+++ b/dev/Scripts/3.0_Boat.cos
@@ -181,7 +181,7 @@ scrp 3 1 50201 1001
 		enum 3 13 50201
 			doif ov00 eq 1
 				doif ooww ov01 eq 3
-					
+		tick 0			
 					* spas takes some time to work, so loop
 					* and keep checking if you got a creature
 					* before continuing
@@ -269,7 +269,7 @@ scrp 3 1 50201 1001
 		enum 3 13 50201
 			doif ov00 eq 0
 				doif ooww ov01 eq 3
-		
+		tick 0
 					* spas takes some (inconsistent amount of) to work, so loop
 					* and keep checking if you got a creature
 					* before continuing

--- a/dev/Scripts/3.0_Shuttle.cos
+++ b/dev/Scripts/3.0_Shuttle.cos
@@ -177,7 +177,7 @@ scrp 3 1 50204 1001
 	enum 3 13 50204
 		doif ov00 eq 1
 			doif ooww ov01 eq 3
-
+tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing
@@ -294,7 +294,7 @@ scrp 3 1 50204 1002
 	enum 3 13 50204
 		doif ov00 eq 0
 			doif ooww ov01 eq 3
-
+tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing

--- a/dev/Scripts/3.0_Submarine.cos
+++ b/dev/Scripts/3.0_Submarine.cos
@@ -245,7 +245,7 @@ scrp 3 1 50202 1001
 		enum 3 13 50202
 			doif ov00 eq 1
 				doif ooww ov01 eq 3
-					
+					tick 0
 					* spas takes some time to work, so loop
 					* and keep checking if you got a creature
 					* before continuing
@@ -1022,7 +1022,7 @@ scrp 3 1 50202 1002
 		enum 3 13 50202
 			doif ov00 eq 0
 				doif ooww ov01 eq 3
-					
+					tick 0
 					* spas takes some time to work, so loop
 					* and keep checking if you got a creature
 					* before continuing

--- a/dev/Scripts/3.0_Trolly.cos
+++ b/dev/Scripts/3.0_Trolly.cos
@@ -240,7 +240,7 @@ scrp 3 1 50205 1001
 		enum 3 13 50205
 			doif ov00 eq -5
 				doif ooww ov01 eq 3
-
+tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing
@@ -309,7 +309,7 @@ scrp 3 1 50205 1002
 		enum 3 13 50205
 			doif ov00 eq 5
 				doif ooww ov01 eq 3
-
+tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing

--- a/dev/Scripts/3.0_Yellow_Raft.cos
+++ b/dev/Scripts/3.0_Yellow_Raft.cos
@@ -174,7 +174,7 @@ scrp 3 1 50203 1001
 			enum 3 13 50203
 				doif ov00 eq 1
 					doif ooww ov01 eq 3
-
+					tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing
@@ -257,7 +257,7 @@ scrp 3 1 50203 1001
 			enum 3 13 50203
 				doif ov00 eq 0
 					doif ooww ov01 eq 3
-
+tick 0
 * spas takes some time to work, so loop
 * and keep checking if you got a creature
 * before continuing


### PR DESCRIPTION
Believe a problem was caused where due to a wait 1 needed for spas to pick something up, during that time a queue could realize it's creature was being carried and destroy itself, so when the agent continues it's script suddenly the queue no longer exists :P