### PR TITLE
Bat/Tendril/Mushroom runtime error fixes

### DIFF
--- a/dev/Scripts/2.0_Deathcap_Mushroom.cos
+++ b/dev/Scripts/2.0_Deathcap_Mushroom.cos
@@ -6,6 +6,7 @@
 * Verm here, to make the detritus edible/toxic friendly! And I guess generally a bit too...
 * Aiko fixed some syntax weirdnesses
 * The one who screams made spores invisible to creatures
+* NeoDement attempted to a fix a bug where XY coords were grabbed from an invalid object, resulting in a MVSF command trying to put a mushroom out of bounds.
 
 reps rand 1 2
 
@@ -195,7 +196,9 @@ scrp 2 3 50218 9
 
 			gsub check
 
-			slow
+*			slow
+			
+			inst
 
 			setv va00 posl
 
@@ -224,6 +227,8 @@ scrp 2 3 50218 9
 			anim [4 5 6]
 
 			kill ownr
+			
+			slow
 
 		else
 
@@ -406,11 +411,13 @@ endm
 
 scrp 2 5 50200 9
 
+*delete yourself if you're underwater
 	doif rtyp grap posx posy eq 8 and rtyp grap posx posy eq 9
 
 		kill ownr
 
 	endi
+
 
 	doif ov00 eq 1
 
@@ -469,6 +476,8 @@ scrp 2 5 50200 9
 					addv va00 rand -10 10
 
 					reps rand 2 3
+					
+						inst
 
 						new: simp 2 3 50218 "moe_C2toDS_deathcap" 7 13 rand 1000 5000
 
@@ -477,6 +486,8 @@ scrp 2 5 50200 9
 						velo rand -2 2 rand 0 -5
 
 						targ ownr
+						
+						slow
 
 					repe
 

--- a/dev/Scripts/2.0_Tendrils.cos
+++ b/dev/Scripts/2.0_Tendrils.cos
@@ -1,17 +1,24 @@
 * 2 3 50220 - Walking Tendril Seed
 * 2 5 50203 - Walking Tendril
 * 2 23 50209 - Walking Tendril Seed Vendor
-** Seed vendor is invisible to creatures (for the time being)
+** todo: Seed vendor is invisible to creatures (for the time being)
 
 *Walking Tendril
 
 *Moe 2010
 
+*NeoDement cleaned up a bit and attempted to fix a rare bug probably caused by changing FRAT mid-anim.
+*Also made it spawn 2 fully grown tendrils in the green house instead of having the seed launcher launch a seed when created.
+*Also improved anims a bit.
+
+*todo: improve anims?
+
+
 *Vendor
 
 new: simp 2 23 50209 "moe_C2toDS_tend" 6 0 5000
 
-mvsf 4032 49672
+mvto 4032 49672
 
 setv va00 0
 
@@ -21,6 +28,40 @@ prt: onew 0 "Output" "Sends signal inputs from the tendril layer." 47 58
 
 
 
+
+
+*make 2 full grown tendrils
+
+new: simp 2 5 50203 "moe_C2toDS_tend" 21 8 2100
+
+tick 200
+
+attr 199
+
+bhvr 11
+
+pose 5
+
+mvto 3951 49612
+
+
+new: simp 2 5 50203 "moe_C2toDS_tend" 21 8 2000
+
+tick 300
+
+attr 199
+
+bhvr 11
+
+pose 5
+
+mvto 4297 49612
+
+
+
+
+
+*Seed Vendor Create Script
 
 scrp 2 23 50209 10
 
@@ -32,11 +73,14 @@ scrp 2 23 50209 10
 
 	perm 51
 
-	mesg writ targ 0
+*C2 framerate
+	frat 2
 
 endm
 
 
+
+*Seed Vendor Collision Script
 
 scrp 2 23 50209 6
 
@@ -53,6 +97,8 @@ scrp 2 23 50209 6
 endm
 
 
+
+*Seed Vendor Activate 1 Script
 
 scrp 2 23 50209 1
 
@@ -78,9 +124,8 @@ scrp 2 23 50209 1
 
 	addv va01 10
 
+
 *Create Tendril Seed*
-
-
 
 	new: simp 2 3 50220 "moe_C2toDS_tend" 1 6 rand 50 2000
 
@@ -124,11 +169,14 @@ scrp 2 3 50220 10
 
 	mira rand 0 1
 
+*C2 framerate
+	frat 2
+
 endm
 
 
 
-*Seed Timer
+*Seed Timer Script
 
 scrp 2 3 50220 9
 
@@ -227,10 +275,12 @@ scrp 2 3 50220 9
 	retn
 
 
-
 endm
 
 
+
+
+*Seed Collision Script
 
 scrp 2 3 50220 6
 
@@ -239,6 +289,9 @@ scrp 2 3 50220 6
 endm
 
 
+
+
+*Seed Eat Script
 
 scrp 2 3 50220 12
 
@@ -252,9 +305,12 @@ endm
 
 
 
-*Tendril Create
+
+*Tendril Create Script
 
 scrp 2 5 50203 10
+
+	inst
 
 	perm 51
 
@@ -276,16 +332,20 @@ scrp 2 5 50203 10
 
 	bhvr 0
 
+*C2 framerate
+	frat 2
+
 endm
 
 
 
+
+*Tendril Timer Script
+
 scrp 2 5 50203 9
 
+	doif pose lt 5
 
-
-	doif pose lt 6
-		
 		attr 211
 
 		setv va00 pose
@@ -334,6 +394,7 @@ scrp 2 5 50203 9
 
 				setv va01 posb
 
+*create walking tendril seed
 				new: simp 2 3 50220 "moe_C2toDS_tend" 1 6 rand 50 2000
 
 				mvsf va00 va01
@@ -422,6 +483,9 @@ scrp 2 5 50203 9
 
 		reps rand 4 5
 
+*stop current anim. possible fix for engine error caused by changing frat mid-anim.
+			anim []
+
 			frat 2
 
 			anim [6 7 8 9 10]
@@ -440,6 +504,8 @@ scrp 2 5 50203 9
 
 		repe
 
+		anim [9 8 7 6 5]
+
 	retn
 
 
@@ -450,21 +516,73 @@ endm
 
 
 
+*Tendril Activate 1 Script
+
 scrp 2 5 50203 1
 
+*	targ from
+*	doif fmly eq 4
+	stim writ from 83 1
+*	endi
+
+	call 1000 from 0
+
+endm
+
+
+
+
+
+*Tendril Activate 2 Script
+
+scrp 2 5 50203 2
+
+*	targ from
+*	doif fmly eq 4
+	stim writ from 83 1
+*	endi
+
+	call 1000 from 0
+
+endm
+
+
+
+
+*Tendril Hit Script
+
+scrp 2 5 50203 3
+
+*	targ from
+*	doif fmly eq 4
+	stim writ from 83 1
+*	endi
+
+*todo: an actual hit script would be more fun!
+
+	call 1000 from 0
+
+endm
+
+
+
+
+
+
+
+
+
+*Tendril Script 1000 - Called by Activate 1, Activate 2 and currently Hit
+
+*_P1_ is FROM
+
+scrp 2 5 50203 1000
 
 
 *Poke Norns, Move
 
 
-	targ from
-	doif fmly eq 4 
-		stim writ from 83 1
-	endi
-
-
-
-	doif from ne pntr
+	doif _p1_ ne pntr
 
 		doif relx ownr from gt 0
 
@@ -480,7 +598,7 @@ scrp 2 5 50203 1
 
 		sndc "stng"
 
-		targ from
+		targ _p1_
 
 		setv va00 posl
 
@@ -504,6 +622,8 @@ scrp 2 5 50203 1
 
 	reps rand 4 5
 
+*stop current anim. possible fix for engine error caused by changing frat mid-anim.
+		anim []
 		frat 2
 
 		anim [6 7 8 9 10]
@@ -522,38 +642,15 @@ scrp 2 5 50203 1
 
 	repe
 
-
-
-
+	anim [9 8 7 6 5]
 
 endm
 
 
 
-scrp 2 5 50203 2
-	
-	targ from
-	doif fmly eq 4 
-		stim writ from 83 1
-	endi
-
-	mesg writ ownr 0
-
-endm
 
 
-
-scrp 2 5 50203 3
-
-	targ from
-	doif fmly eq 4 
-		stim writ from 83 1
-	endi
-
-	mesg writ ownr 0
-
-endm
-
+*no more tendrils
 
 rscr
 

--- a/dev/Scripts/2.2_Bats.cos
+++ b/dev/Scripts/2.2_Bats.cos
@@ -4,18 +4,26 @@
 * for now, these are all invisible to creatures. If at some point we feel like 
 * adding push/pull/hit/eat scripts we can change that. - Aiko
 
+*NeoDement fixed an invalid agent error when the bat attempts to eat food that doesn't exist anymore.
+
+
+*Install
+
 new: simp 2 17 50204 "moe_C2toDS_bats" 1 60 0
 
-mvsf 7572 48910
+mvto 7572 48910
 
 
 
 new: simp 2 17 50204 "moe_C2toDS_bats" 1 60 0
 
-mvsf 3890 48950
+mvto 3890 48950
+
+cmrt 0
 
 
 
+*Bat Nest Constructor Script
 
 scrp 2 17 50204 10
 
@@ -42,6 +50,7 @@ scrp 2 17 50204 10
 endm
 
 
+*Bat Constructor Script
 
 scrp 2 16 50203 10
 
@@ -54,6 +63,9 @@ scrp 2 16 50203 10
 	elas 0
 
 	fric 50
+
+*C2 framerate
+	frat 2
 
 
 
@@ -91,7 +103,7 @@ scrp 2 16 50203 10
 
 
 
-	tick rand 19.5 25
+	tick rand 20 25
 
 
 
@@ -100,6 +112,7 @@ scrp 2 16 50203 10
 endm
 
 
+*Bat Timer Script
 
 scrp 2 16 50203 9
 
@@ -189,13 +202,9 @@ scrp 2 16 50203 9
 
 		setv ov13 3
 
-		frat 2
-
 		anim [16 17 18 19 20]
 
 		over
-
-		frat 2
 
 		anim [26 27 28 29]
 
@@ -213,13 +222,9 @@ scrp 2 16 50203 9
 
 			setv ov13 1
 
-			frat 2
-
 			anim [16 17 18 19 20]
 
 			over
-
-			frat 2
 
 			anim [26 27 28 29]
 
@@ -237,13 +242,9 @@ scrp 2 16 50203 9
 
 	subr wakeup
 
-		frat 2
-
 		anim [29 28 27 26]
 
 		over
-
-		frat 2
 
 		anim [8 9 10 11]
 
@@ -278,8 +279,6 @@ scrp 2 16 50203 9
 				base 30
 
 			endi
-
-			frat 2
 
 			anim [0 1 2 3 2 1 255]
 
@@ -494,7 +493,10 @@ scrp 2 16 50203 9
 
 					drop
 
-					mesg writ ov08 12
+*the "eat" subroutine puts us in slow mode, which gives the food a few ticks to disappear. so check if it still exists before you run the eat script (12).
+					doif ov08 <> null
+						mesg writ ov08 12
+					endi
 
 					gsub wakeup
 
@@ -1059,12 +1061,17 @@ scrp 2 16 50203 9
 endm
 
 
+*Bat Drop Script
 
 scrp 2 16 50203 5
 
 	setv ov14 1
 
 endm
+
+
+
+*no bats? :(
 
 rscr
 

--- a/dev/Scripts/2.2_Bats.cos
+++ b/dev/Scripts/2.2_Bats.cos
@@ -1,7 +1,7 @@
 *Bat 2 16 50203 
 *Bat Nest 2 17 50204 <----4*****
 
-* for now, these are all invisible to creatures. If at some point we feel like 
+* todo: for now, these are all invisible to creatures. If at some point we feel like 
 * adding push/pull/hit/eat scripts we can change that. - Aiko
 
 *NeoDement fixed an invalid agent error when the bat attempts to eat food that doesn't exist anymore.

--- a/dev/Scripts/2.2_Bats.cos
+++ b/dev/Scripts/2.2_Bats.cos
@@ -19,8 +19,6 @@ new: simp 2 17 50204 "moe_C2toDS_bats" 1 60 0
 
 mvto 3890 48950
 
-cmrt 0
-
 
 
 *Bat Nest Constructor Script


### PR DESCRIPTION
Bats:

-Fixed invalid agent error when bats attempts to eat food that doesn't exist anymore

Walking Tendrils:

-Cleaned up a bit and attempted to fix a rare bug probably caused by changing FRAT mid-anim.
-Made the script spawn 2 fully grown tendrils in the green house instead of having the seed launcher launch a seed when created.
-Slight anim improvements

Deathcap Mushrooms:

-Attempted to a fix a bug where XY coords were grabbed from an invalid object, resulting in a MVSF command trying to put a mushroom out of bounds.