### PR TITLE
fixed mushroom patch dropping through the floor

### DIFF
--- a/dev/Scripts/2.0_Little_Mushrooms.cos
+++ b/dev/Scripts/2.0_Little_Mushrooms.cos
@@ -698,7 +698,7 @@ scrp 2 24 50208 1
 
 		subv va00 46
 
-		setv va01 posb
+		setv va01 post
 
 		new: simp 2 4 50201 "moe_C2toDS_mush" 0 16 rand 1000 5000
 


### PR DESCRIPTION
I noticed the mushroom patch falling through the floor to the next room down when injected with the mushroom maker thingy. I fixed it by changing the position calculated for the injection to use the top of the maker rather than the bottom.