### PR TITLE
various teleporter enhancements+fav place add conditional script override to fix camera bug

### DIFF
--- a/dev/Scripts/1.1_Fav_Place.cos
+++ b/dev/Scripts/1.1_Fav_Place.cos
@@ -4,7 +4,7 @@ new: simp 1 3 50200 "moe_C2toDS_Fav" 1 0 1
 
 attr 272
 
-mvto 6753 48383
+mvto 7154 48406
 
 tick 10
 

--- a/dev/Scripts/1.1_Fav_Place.cos
+++ b/dev/Scripts/1.1_Fav_Place.cos
@@ -1,5 +1,3 @@
-**Changing all the links from 1 to 100 since they need an int, I think that's correct - Verm
-
 *Create Signpost*
 
 new: simp 1 3 50200 "moe_C2toDS_Fav" 1 0 1
@@ -9,6 +7,68 @@ attr 272
 mvto 6753 48383
 
 tick 10
+
+
+
+
+
+
+*NeoDement: added an override for the default DS fav places script to move camera twice to account for bug when switching metaroom
+
+**********************ICON EVENTS
+******Icon clicked on
+scrp 1 4 50200 1
+
+*	dbg: asrt "signpost" = "fixed"
+
+	inst
+*	get your species number
+	setv va00 spcs
+*	find your counterpart signpost
+	rtar 1 3 va00
+	doif targ eq null
+*	no targ, stop
+		stop
+	endi
+*	move camera to them
+	cmrt 0
+	cmrt 0
+*	give all agents a 'metaroom has changed' message
+	enum 0 0 0
+		mesg writ targ 900
+	next
+
+endm
+
+
+*NeoDement: delete our override script if the global signpost Activate behaviour has been modified in any way
+
+scrp 1 4 50200 10
+	inst
+
+*ONLY RUN OUR MODIFIED SCRIPT IF THE DEFAULT SIGNPOST BEHAVIOUR IS PRESENT!
+*this should hopefully allow custom signpost systems to not break.
+	sets va99 sorc 1 4 0 1
+
+*erase whitespace from end of string
+	doif subs va99 strl va99 1 = " "
+		loop
+			setv va80 strl va99
+			subv va80 1
+			sets va99 subs va99 1 va80
+		untl subs va99 strl va99 1 <> " "
+	endi
+
+*look for an exact match of the default script
+	doif va99 <> "inst setv va00 spcs rtar 1 3 va00 doif targ eq null stop endi cmrt 0 enum 0 0 0 mesg writ targ 900 next"
+		scrx 1 4 50200 1
+*		dbg: asrt "script" = "wrong"
+	endi
+
+endm
+
+
+
 
 
 rscr

--- a/dev/Scripts/3.0_Teleporters.cos
+++ b/dev/Scripts/3.0_Teleporters.cos
@@ -1,4 +1,4 @@
-* 3 2 50200 - Big Teleporters (one in DS Workshop and one in C2 incubator room)
+* 3 2 50200 - Big Teleporters (one in DS Corridor and one in C2 incubator room)
 * 3 2 50202 - All other Teleporters
 * 1 17 50201 - Teleporter Beam Animation
 
@@ -9,6 +9,11 @@
 *-the camera now jumps to the other side of the teleporter when clicking it with both types of teleporter (previously only worked with big ones)
 *-made IO ports more obvious (only small teleporters have IO ports)
 *-added stims to regular teleporters. previously only big teleporters actually let norns know they'd used a teleporter.
+*-moved DS-side Big Teleporter to the corridor on the left (opposite side of the C12DS tele). This looks cool if you inject both at the same time.
+
+
+*NOTE: also defined in "1.2_!World_Wrap.cos"
+setv game "C2toDS_RoomID" gmap 6753 48383
 
 
 *Teleporter - Norn Burrow (MAIN)
@@ -88,7 +93,7 @@ scrp 3 2 50200 10
 
 		seta ov01 ownr
 
-		mvto 4463 9013
+		mvto 2350 9010
 
 		attr 199
 
@@ -252,6 +257,10 @@ scrp 3 2 50200 1001
 
 	setv va01 posb
 
+*for nicer centered camera after teleports
+	setv va11 posy
+
+
 *addv va01 200
 
 	targ ownr
@@ -259,7 +268,27 @@ scrp 3 2 50200 1001
 *_P1_ is FROM
 	doif _p1_ eq pntr
 
-		cmrp va00 va01 0
+
+*neodement: move camera twice to account for bug when switching metaroom
+		cmrp va00 va11 0
+		cmrp va00 va11 0
+
+
+
+*neodement: nasty little trick to force the C2toDS signpost to register	first time we tele into c2tods metaroom (it's not on screen for small resolutions)
+		doif meta = game "C2toDS_RoomID"
+			enum 1 3 50200
+				doif ov00 = 0
+					setv va60 posl
+					setv va61 post
+					mvto va00 va01
+					mesg writ targ 9
+					wait 1
+					mvto va60 va61
+					inst
+				endi
+			next
+		endi
 
 	endi
 
@@ -613,6 +642,9 @@ scrp 3 2 50202 1001
 
 	setv va01 posb
 
+*for nicer centered camera after teleports
+	setv va11 posy
+
 	seta va51 targ
 
 	mesg writ targ 1000
@@ -631,7 +663,9 @@ scrp 3 2 50202 1001
 *_P2_ is FROM
 	doif _p2_ eq pntr
 
-		cmrp va00 va01 0
+*neodement: move camera twice to account for bug when switching metaroom
+		cmrp va00 va11 0
+		cmrp va00 va11 0
 
 	endi
 


### PR DESCRIPTION
TELEPORTERS:

-moved DS-side Big Teleporter to the corridor on the left (opposite side of the C12DS tele). This looks cool if you inject both at the same time.
-camera position after teleport is now based on center of sprite rather than bottom
-camera position after teleport is now set twice to workaround a bug (position is now exact when switching between metarooms)
-force register C2toDS signpost when teleporting into the room for the first time (the teleporter is a bit far right from the signpost to guarantee automatic register)

FAV PLACE:

This will fix a bug present in the CMRT command present when switching metarooms where the camera is incorrectly centered, only on this signpost, and only if the default signpost script hasn't been modified in any way.